### PR TITLE
fix: last update accuracy across pages

### DIFF
--- a/app/guides/[[...slug]]/page.tsx
+++ b/app/guides/[[...slug]]/page.tsx
@@ -11,29 +11,33 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
 	const page = guides.getPage(params.slug)
 	if (!page) notFound()
 
-	const time = await getGithubLastEdit({
-		owner: "bryan308",
-		repo: "ca-resources",
-		token: `Bearer ${process.env.GITHUB_TOKEN}`,
-		sha: "main",
-		path: `content/resources/${page.file.flattenedPath}.mdx`,
-	})
+	const path = `content/guides/${page.file.flattenedPath}.mdx`
+
+	const time =
+		process.env.NODE_ENV === "development"
+			? null
+			: await getGithubLastEdit({
+					owner: "bryan308",
+					repo: "ca-resources",
+					token: `Bearer ${process.env.GITHUB_TOKEN}`,
+					sha: "main",
+					path: path,
+			  })
 
 	return (
 		<DocsPage
-			lastUpdate={time ? new Date(time) : new Date()}
+			lastUpdate={time || undefined}
 			tableOfContent={{
 				style: "clerk",
 				single: false,
 			}}
 			editOnGithub={{
-				repo: "ca-resources",
 				owner: "bryan308",
+				repo: "ca-resources",
 				sha: "main",
-				path: `content/guides/${page.file.flattenedPath}.mdx`,
+				path: path,
 			}}
 			toc={page.data.toc}
-			// full={page.data.full}
 		>
 			<DocsTitle>{page.data.title}</DocsTitle>
 			<DocsDescription>{page.data.description}</DocsDescription>

--- a/app/resources/[[...slug]]/page.tsx
+++ b/app/resources/[[...slug]]/page.tsx
@@ -1,5 +1,4 @@
 import { resources } from "@/lib/source"
-// import type { Metadata } from "next"
 import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page"
 import { notFound } from "next/navigation"
 import { MDXContent } from "@content-collections/mdx/react"
@@ -12,29 +11,33 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
 	const page = resources.getPage(params.slug)
 	if (!page) notFound()
 
-	const time = await getGithubLastEdit({
-		owner: "bryan308",
-		repo: "ca-resources",
-		token: `Bearer ${process.env.GITHUB_TOKEN}`,
-		sha: "main",
-		path: `content/resources/${page.file.flattenedPath}.mdx`,
-	})
+	const path = `content/resources/${page.file.flattenedPath}.mdx`
+
+	const time =
+		process.env.NODE_ENV === "development"
+			? null
+			: await getGithubLastEdit({
+					owner: "bryan308",
+					repo: "ca-resources",
+					token: `Bearer ${process.env.GITHUB_TOKEN}`,
+					sha: "main",
+					path: path,
+			  })
 
 	return (
 		<DocsPage
-			lastUpdate={time ? new Date(time) : new Date()}
+			lastUpdate={time || undefined}
 			tableOfContent={{
 				style: "clerk",
 				single: false,
 			}}
 			editOnGithub={{
-				repo: "ca-resources",
 				owner: "bryan308",
+				repo: "ca-resources",
 				sha: "main",
-				path: `content/resources/${page.file.flattenedPath}.mdx`,
+				path: path,
 			}}
 			toc={page.data.toc}
-			full={page.data.full}
 		>
 			<DocsTitle>{page.data.title}</DocsTitle>
 			<DocsDescription>{page.data.description}</DocsDescription>

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -33,10 +33,7 @@ const guides = defineCollection({
 	name: "guides",
 	directory: "content/guides",
 	include: "**/*.mdx",
-	schema: (z) => ({
-		title: z.string(),
-		description: z.string().optional(),
-	}),
+	schema: createDocSchema,
 	transform: transformMDX,
 })
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of page data and metadata in the `app/guides/[[...slug]]/page.tsx` and `app/resources/[[...slug]]/page.tsx` files, as well as a simplification of the schema definition in `content-collections.ts`. The most important changes include the conditional fetching of the last edit time from GitHub, the use of a common path variable, and the use of a predefined schema.

Improvements to page data handling:

* `app/guides/[[...slug]]/page.tsx`: Conditional fetching of the last edit time from GitHub based on the environment and using a common path variable for `getGithubLastEdit` and `editOnGithub`. ([app/guides/[[...slug]]/page.tsxL14-L36](diffhunk://#diff-7dea98c1ec7859ec8ecaa569a34f3fa724556fd5a77ce52fb197be9b99d7dc09L14-L36))
* `app/resources/[[...slug]]/page.tsx`: Similar changes as in `app/guides/[[...slug]]/page.tsx` for conditional fetching of the last edit time from GitHub and using a common path variable. ([app/resources/[[...slug]]/page.tsxL15-L37](diffhunk://#diff-530bef0caf768f4f39bba88ffa0f03c18849c0faf428ce1be53ad652947c45f5L15-L37))

Schema definition simplification:

* [`content-collections.ts`](diffhunk://#diff-adb2400ac3a4a49c396363dfadbe6f0cca96ea96a1248e3390ca3353f1d1d34bL36-R36): Replaced inline schema definition with the `createDocSchema` function for the `guides` collection.

Code cleanup:

* `app/resources/[[...slug]]/page.tsx`: Removed an unnecessary commented-out import statement. ([app/resources/[[...slug]]/page.tsxL2](diffhunk://#diff-530bef0caf768f4f39bba88ffa0f03c18849c0faf428ce1be53ad652947c45f5L2))